### PR TITLE
Better handling of resume/play function

### DIFF
--- a/ios/ReactNativeAudioStreaming.h
+++ b/ios/ReactNativeAudioStreaming.h
@@ -8,6 +8,7 @@
 
 @property (nonatomic, strong) STKAudioPlayer *audioPlayer;
 @property (nonatomic, readwrite) BOOL isPlayingWithOthers;
+@property (nonatomic, readwrite) NSString *lastUrlString;
 @property (nonatomic, retain) NSString *currentSong;
 
 - (void)play;

--- a/ios/ReactNativeAudioStreaming.m
+++ b/ios/ReactNativeAudioStreaming.m
@@ -28,6 +28,7 @@ RCT_EXPORT_MODULE()
       [self registerAudioInterruptionNotifications];
       [self registerRemoteControlEvents];
       [self setNowPlayingInfo:true];
+      self.lastUrlString = @"";
 
       [NSTimer scheduledTimerWithTimeInterval:0.5 target:self selector:@selector(tick:) userInfo:nil repeats:YES];
 
@@ -70,12 +71,13 @@ RCT_EXPORT_METHOD(play:(NSString *) streamUrl)
    if (!self.audioPlayer) {
       return;
    }
-   if (self.audioPlayer.state == STKAudioPlayerStatePaused) {
+   if (self.audioPlayer.state == STKAudioPlayerStatePaused && [self.lastUrlString isEqualToString:streamUrl]) {
       [self.audioPlayer resume];
    } else {
       [self.audioPlayer play:streamUrl];
    }
-   
+
+   self.lastUrlString = streamUrl;
    [self setNowPlayingInfo:true];
 }
 


### PR DESCRIPTION
Use the resume feature only if it is in paused state AND the streamUrl hasn't changed. Otherwise, use play function which stops any previously queued item.