### PR TITLE
Fix for iOS build error

### DIFF
--- a/ios/ReactNativeAudioStreaming.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeAudioStreaming.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(PODS_ROOT)/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -282,6 +283,7 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(PODS_ROOT)/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";


### PR DESCRIPTION
iOS build error: STKAudioPlayer.h not found referenced in issue #10. I was able to test and confirm that it got rid of the build errors for my copy.