### PR TITLE
Add Cocoapods RNAudioStreaming.podspec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In XCode, in the project navigator, select your project. Add `libReactNativeAudi
 3. In XCode, in the project navigator, select your project. Add `libReactNativeAudioStreaming.a` and `libStreamingKit.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4. Run your project (`Cmd+R`)
 
-#### Final step for iOS (required after doing any of three options above)
+### Final step for iOS (required after doing any of three options above)
 
 Update Info.plist file of your Xcode project and add audio background mode
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,18 @@ If you are only looking to play local audio file with app in foreground, please 
 ![Demo iOS](https://raw.githubusercontent.com/tlenclos/react-native-audio-streaming/master/demo_ios.gif)
 ![Demo android](https://raw.githubusercontent.com/tlenclos/react-native-audio-streaming/master/demo_android.gif)
 
-## Getting started
+## First installation step (applied for both iOS & Android)
 
 `$ npm install react-native-audio-streaming --save`
 
-### Mostly automatic installation
+### Next installation steps for iOS (choose one of three options below)
+
+#### 1. Cocoapods installation
+
+1. add `pod 'RNAudioStreaming', :path => './node_modules/react-native-audio-streaming'` to `Podfile`
+2. run `pod install`
+
+#### 2. Mostly automatic installation
 
 `$ react-native link react-native-audio-streaming`
 
@@ -25,9 +32,7 @@ Go to `node_modules` ➜ `react-native-audio-streaming` => `Pods` and drag/drop 
 
 In XCode, in the project navigator, select your project. Add `libReactNativeAudioStreaming.a` and `libStreamingKit.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 
-### Manual installation
-
-#### iOS
+#### 3. Manual installation
 
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2. Go to `node_modules` ➜ `react-native-audio-streaming` => `ios`
@@ -37,7 +42,17 @@ In XCode, in the project navigator, select your project. Add `libReactNativeAudi
 3. In XCode, in the project navigator, select your project. Add `libReactNativeAudioStreaming.a` and `libStreamingKit.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4. Run your project (`Cmd+R`)
 
-#### Android
+#### Final step for iOS (required after doing any of three options above)
+
+Update Info.plist file of your Xcode project and add audio background mode
+
+```xml
+    <key>UIBackgroundModes</key>
+    <array>
+    <string>audio</string>
+```
+
+### Next installation steps for Android
 
 1. Open up `android/app/src/main/java/[...]/MainApplication.java`
   - Add `import com.audioStreaming.ReactNativeAudioStreamingPackage;` to the imports at the top of the file
@@ -55,14 +70,6 @@ In XCode, in the project navigator, select your project. Add `libReactNativeAudi
   	```
   	
 ## Usage
-
-### iOS only : udate the Info.plist file of your project and add background mode
-
-```xml
-    <key>UIBackgroundModes</key>
-    <array>
-    <string>audio</string>
-```
 
 ### Playing sound (similar code used by the player UI)
 

--- a/RNAudioStreaming.podspec
+++ b/RNAudioStreaming.podspec
@@ -1,0 +1,26 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                = "RNAudioStreaming"
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.homepage            = "https://github.com/tlenclos/react-native-audio-streaming"
+  s.license             = package['license']
+  s.author              = package['author']
+  s.source              = { :git => package['repository']['url'], :tag => "v#{s.version}" }
+  s.default_subspec     = 'Main'
+  s.requires_arc        = true
+  s.platform            = :ios, "7.0"
+  s.preserve_paths      = "**/*.js"
+
+  s.subspec 'Main' do |ss|
+    ss.source_files     = "ios/ReactNativeAudioStreaming.{h,m}"
+    ss.dependency       'RNAudioStreaming/StreamingKit'
+  end
+
+  s.subspec 'StreamingKit' do |ss|
+    ss.source_files     = "ios/Pods/StreamingKit/StreamingKit/StreamingKit/**/*.{h,m}"
+  end
+end


### PR DESCRIPTION
so that we can install using these steps:
1. run `npm install react-native-audio-streaming --save`
2. add `pod 'RNAudioStreaming', :path => './node_modules/react-native-audio-streaming'` to `Podfile`
3. run `pod install`