### PR TITLE
Use empty string instead of missing StreamTitle.

### DIFF
--- a/ios/ReactNativeAudioStreaming.m
+++ b/ios/ReactNativeAudioStreaming.m
@@ -216,11 +216,11 @@ RCT_EXPORT_METHOD(getStatus: (RCTResponseSenderBlock) callback)
 - (void)audioPlayer:(STKAudioPlayer *)audioPlayer didReadStreamMetadata:(NSDictionary *)dictionary {
    NSLog(@"AudioPlayer SONG NAME  %@", dictionary[@"StreamTitle"]);
    
-   self.currentSong = dictionary[@"StreamTitle"];
+   self.currentSong = dictionary[@"StreamTitle"] ? dictionary[@"StreamTitle"] : @"";
    [self.bridge.eventDispatcher sendDeviceEventWithName:@"AudioBridgeEvent" body:@{
                                                                                    @"status": @"METADATA_UPDATED",
                                                                                    @"key": @"StreamTitle",
-                                                                                   @"value": dictionary[@"StreamTitle"]
+                                                                                   @"value": self.currentSong
                                                                                    }];
    [self setNowPlayingInfo:true];
 }


### PR DESCRIPTION
This prevents process from crashing when StreamTitle does not exist in
the dictionary.