### PR TITLE
Fix for Android player notification not closing on app close

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
         <service
             android:name="com.audioStreaming.Signal"
             android:enabled="true"
-            android:theme="@android:style/Theme.NoTitleBar"/>
+            android:theme="@android:style/Theme.NoTitleBar"
+            android:stopWithTask="true"/>
     </application>
 </manifest>
   


### PR DESCRIPTION
Fixes the issue when the notification would freeze if audio was playing and you closed the app.
closes #49