### PR TITLE
Android app crashed when trying to update metadata with notification not initialized

### DIFF
--- a/android/src/main/java/com/audioStreaming/Signal.java
+++ b/android/src/main/java/com/audioStreaming/Signal.java
@@ -329,7 +329,7 @@ public class Signal extends Service implements OnErrorListener,
         metaIntent.putExtra("value", value);
         sendBroadcast(metaIntent);
 
-        if (key != null && key.equals("StreamTitle")) {
+        if (key != null && key.equals("StreamTitle") && remoteViews != null) {
             remoteViews.setTextViewText(R.id.song_name_notification, value);
             notifyBuilder.setContent(remoteViews);
             notifyManager.notify(NOTIFY_ME_ID, notifyBuilder.build());


### PR DESCRIPTION
Currently when android notification is turned off `showInAndroidNotifications: false`

App crashes when you start the player. This happens because player tries to update `remoteViews` that refers to the notification that is `null`. 

This fix will avoid trying to update the remoteViews