### PR TITLE
Do not reset MPNowPlayingInfoCenter if showIniOSMediaCenter is not set.

### DIFF
--- a/ios/ReactNativeAudioStreaming.m
+++ b/ios/ReactNativeAudioStreaming.m
@@ -444,8 +444,6 @@ RCT_EXPORT_METHOD(getStatus: (RCTResponseSenderBlock) callback)
                                       appName ? appName : @"AppName", MPMediaItemPropertyTitle,
                                       [NSNumber numberWithFloat:isPlaying ? 1.0f : 0.0], MPNowPlayingInfoPropertyPlaybackRate, nil];
       [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = nowPlayingInfo;
-   } else {
-      [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = nil;
    }
 }
 


### PR DESCRIPTION
Currently `react-native-audio-streaming` removes all Now Playing data if `showIniOSMediaCenter` is not set. This prevents users of the library from updating the Now Playing information using some other code in the same app.

I think the library should not touch `nowPlayingInfo` at all unless `showIniOSMediaCenter` is set.