### PR TITLE
Add Proguard instructions for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,15 @@ In XCode, in the project navigator, select your project. Add `libReactNativeAudi
   	```
       compile project(':react-native-audio-streaming')
   	```
-  	
+4. If using Proguard then insert the following rules:
+   ```
+   -keep class com.spoledge.aacdecoder.** {
+    *;
+   }
+   ```
+
+   
+   
 ## Usage
 
 ### Playing sound (similar code used by the player UI)


### PR DESCRIPTION
I needed to add these lines to my Proguard config, otherwise app would crash when I attempted to play audio, with "class not found" errors.
