### PR TITLE
Fix Error: Redefinition of RCTMethodInfo

### DIFF
--- a/ios/ReactNativeAudioStreaming.h
+++ b/ios/ReactNativeAudioStreaming.h
@@ -1,7 +1,12 @@
 // AudioManager.h
 // From https://github.com/jhabdas/lumpen-radio/blob/master/iOS/Classes/AudioManager.h
 
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#else
 #import "RCTBridgeModule.h"
+#endif
+
 #import "STKAudioPlayer.h"
 
 @interface ReactNativeAudioStreaming : NSObject <RCTBridgeModule, STKAudioPlayerDelegate>

--- a/ios/ReactNativeAudioStreaming.m
+++ b/ios/ReactNativeAudioStreaming.m
@@ -1,4 +1,9 @@
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#else
 #import "RCTBridgeModule.h"
+#endif
+
 #import "RCTEventDispatcher.h"
 
 #import "ReactNativeAudioStreaming.h"


### PR DESCRIPTION
This pull request will solve the Error: Redefinition of RCTMethodInfo what was going on when we try to build the app on xcode with the React Native version >= 0.48.