### PR TITLE
Android - Audio Focus Request & Wait

### DIFF
--- a/android/src/main/java/com/audioStreaming/ReactNativeAudioStreamingPackage.java
+++ b/android/src/main/java/com/audioStreaming/ReactNativeAudioStreamingPackage.java
@@ -22,7 +22,7 @@ public class ReactNativeAudioStreamingPackage implements ReactPackage {
         return modules;
     }
 
-    // Deprecated RN 0.47
+    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
I noticed that on Android, sound can overlap between applications so this addition will use `AudioManager` to request audio focus and play the sound _after_ it has been granted. 